### PR TITLE
run averaging step on calling machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ The general idea is that you clone this repository for each new template brain p
 
     git clone git@github.com:jefferis/MakeAverageBrain.git <NameOfNewTemplate>
 
-then fill the directories as described below, and finally run the code.
+then fill the directories as described below, and finally run the code. If you do not have git
+you can just [download the zip](https://github.com/jefferislab/MakeAverageBrain/archive/feature/average-on-hex.zip)
+file, expand and rename the resultant folder to <NameOfNewTemplate>.
 
 ## Images
 

--- a/commands/makeAverageBrain-sync.sh
+++ b/commands/makeAverageBrain-sync.sh
@@ -93,7 +93,9 @@ while [ $i -le $NOITERATIONS ]; do
 
 	if [ ! -f "${REGROOT}/refbrain/${NEWREFBRAIN}.nrrd" ] ; then
 		# if average brain doesn't exist (eg if a run was interrupted then make it)
-		qsub -sync yes -wd "$REGROOT/jobs" -S /bin/bash -m eas -M ${LMBUSER}@lmb.internal -pe smp 8 "$REGROOT/commands/avgcmdIterationPadOut.sh" ${CURREFBRAIN} ${NEWREFBRAIN} ${REGROOT} ${REGBINDIR}
+		#qsub -sync yes -wd "$REGROOT/jobs" -S /bin/bash -m eas -M ${LMBUSER}@lmb.internal -pe smp 8 "$REGROOT/commands/avgcmdIterationPadOut.sh" ${CURREFBRAIN} ${NEWREFBRAIN} ${REGROOT} ${REGBINDIR}
+		cd "$REGROOT/jobs" && /bin/bash "$REGROOT/commands/avgcmdIterationPadOut.sh" ${CURREFBRAIN} ${NEWREFBRAIN} ${REGROOT} ${REGBINDIR}
+		cd "$REGROOT"
 	fi
 	if [ ! -f "${REGROOT}/refbrain/${NEWREFBRAIN}.nrrd" ] ; then
 		echo Exiting $PROGNAME since avg_adm failed to make $NEWREFBRAIN


### PR DESCRIPTION
- this is usually one of the head machines with large amounts of memory
- averaging is memory intensive and sometimes breaks on the cluster
